### PR TITLE
Implement basic Flask CRM skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.pyc
+__pycache__/
+instance/
+pytest_cache/
+crm.db

--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# VivaTerra Cameroun CRM
+
+This repository contains a minimal customer relationship management (CRM) application built with Flask.
+
+## Features
+
+- Manage client records (add, list, delete)
+- Uses SQLite for data storage
+- Simple REST style API
+
+## Quick start
+
+```bash
+pip install -r requirements.txt
+python -m crm.app  # starts the development server
+```
+
+Running tests:
+
+```bash
+pytest
+```
+
+The application will create `crm.db` automatically on first run.
+

--- a/crm/__init__.py
+++ b/crm/__init__.py
@@ -1,0 +1,10 @@
+from flask import Flask
+from flask_sqlalchemy import SQLAlchemy
+
+app = Flask(__name__)
+app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///crm.db'
+app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+
+db = SQLAlchemy(app)
+
+from . import routes

--- a/crm/app.py
+++ b/crm/app.py
@@ -1,0 +1,5 @@
+from . import app
+import crm.routes  # noqa: F401
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/crm/routes.py
+++ b/crm/routes.py
@@ -1,0 +1,39 @@
+from flask import request, jsonify
+from . import app, db
+
+class Client(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(100), nullable=False)
+    email = db.Column(db.String(120), unique=True, nullable=False)
+    phone = db.Column(db.String(50))
+
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'name': self.name,
+            'email': self.email,
+            'phone': self.phone,
+        }
+
+with app.app_context():
+    db.create_all()
+
+@app.route('/clients', methods=['GET'])
+def list_clients():
+    clients = Client.query.all()
+    return jsonify([c.to_dict() for c in clients])
+
+@app.route('/clients', methods=['POST'])
+def create_client():
+    data = request.get_json(force=True)
+    client = Client(name=data['name'], email=data['email'], phone=data.get('phone'))
+    db.session.add(client)
+    db.session.commit()
+    return jsonify(client.to_dict()), 201
+
+@app.route('/clients/<int:client_id>', methods=['DELETE'])
+def delete_client(client_id):
+    client = Client.query.get_or_404(client_id)
+    db.session.delete(client)
+    db.session.commit()
+    return '', 204

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask==3.0.2
+Flask-SQLAlchemy==3.1.1
+pytest==8.2.0

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,30 @@
+import json
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from crm import app, db
+from crm.routes import Client
+
+
+def setup_app(tmp_path):
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///' + str(tmp_path / "test.db")
+    app.config['TESTING'] = True
+    with app.app_context():
+        db.create_all()
+    return app.test_client()
+
+
+def test_create_and_list_client(tmp_path):
+    client = setup_app(tmp_path)
+    response = client.post('/clients', json={'name': 'Alice', 'email': 'alice@example.com'})
+    assert response.status_code == 201
+    data = response.get_json()
+    assert data['name'] == 'Alice'
+
+    response = client.get('/clients')
+    assert response.status_code == 200
+    data = response.get_json()
+    assert len(data) == 1
+    assert data[0]['email'] == 'alice@example.com'


### PR DESCRIPTION
## Summary
- add a minimal Flask-based CRM application
- provide REST API for managing clients
- include tests using pytest
- add usage instructions in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68436fcf458083319bfcf157acc7042b